### PR TITLE
feat: add masterplan types

### DIFF
--- a/src/types/masterplan.ts
+++ b/src/types/masterplan.ts
@@ -1,0 +1,28 @@
+export interface Masterplan {
+  creative_vision: string;
+  masterplan: {
+    title: string;
+    artistCredits: string;
+    global: {
+      targetBPM: number;
+      targetKey: string;
+      timeSignature: [number, number];
+    };
+    timeline: Array<{
+      time_start_sec: number;
+      duration_sec: number;
+      description: string;
+      energy_level: number;
+      layers: Array<{
+        songId: string;
+        stem: string;
+        volume_db: number;
+        effects: string[];
+      }>;
+    }>;
+    problems_and_solutions: Array<{
+      problem: string;
+      solution: string;
+    }>;
+  };
+}


### PR DESCRIPTION
## Summary
- define Masterplan interface for orchestrator response
- apply Masterplan typing and optional checks in useMashupOrchestrator hook

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a04277efb88322bbf35e55e4fe96dd