### PR TITLE
feat: clarify orchestrator env var handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,7 @@ ORCHESTRATOR_API_URL=https://tylers-remixer-orchestrator.loca.lt
 SEPARATION_API_URL=https://tylers-remixer-separation.loca.lt
 ```
 
+The `ORCHESTRATOR_API_URL` is required by the `claude-mashup-orchestrator` Supabase function.
+If it's missing, the function logs a warning at startup and returns a clear JSON error explaining that the variable is not set.
+
 You will also need to add your `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `ANTHROPIC_API_KEY`. Refer to the `.env.example` file for the full list.

--- a/supabase/functions/claude-mashup-orchestrator/index.ts
+++ b/supabase/functions/claude-mashup-orchestrator/index.ts
@@ -3,50 +3,69 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
+// Load the orchestrator URL at startup and warn if it's missing
+const orchestratorApiUrl = Deno.env.get('ORCHESTRATOR_API_URL');
+if (!orchestratorApiUrl) {
+  console.warn(
+    'Warning: ORCHESTRATOR_API_URL environment variable is not set. Requests will fail.'
+  );
+}
+
 Deno.serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders });
-  }
+if (req.method === 'OPTIONS') {
+  return new Response('ok', { headers: corsHeaders });
+}
 
-  try {
-    const body = await req.json();
-
-    const orchestratorApiUrl = Deno.env.get('ORCHESTRATOR_API_URL');
-    if (!orchestratorApiUrl) {
-        throw new Error('ORCHESTRATOR_API_URL environment variable is not set.');
-    }
-
-    // Forward the request to the Python orchestrator service
-    const response = await fetch(`${orchestratorApiUrl}/create-masterplan`, {
-      method: 'POST',
-      headers: { 
-        'Content-Type': 'application/json',
-        'User-Agent': 'Supabase-Edge-Function/1.0',
-        'bypass-tunnel-reminder': 'true'
-      },
-      body: JSON.stringify(body)
-    });
-
-    if (!response.ok) {
-        const errorBody = await response.text();
-        throw new Error(`Orchestrator service failed: ${response.statusText} - ${errorBody}`);
-    }
-
-    const result = await response.json();
-
-    return new Response(JSON.stringify(result), {
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-    });
-
-  } catch (error) {
-    console.error('Error in claude-mashup-orchestrator proxy:', error.message);
-    return new Response(JSON.stringify({
-      error: 'Failed to create masterplan',
-      details: error.message
-    }), {
+if (!orchestratorApiUrl) {
+  return new Response(
+    JSON.stringify({
+      error: 'Missing environment variable',
+      details: 'ORCHESTRATOR_API_URL environment variable is not set.',
+    }),
+    {
       status: 500,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-    });
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    }
+  );
+}
 
+try {
+  const body = await req.json();
+
+  // Forward the request to the Python orchestrator service
+  const response = await fetch(`${orchestratorApiUrl}/create-masterplan`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'User-Agent': 'Supabase-Edge-Function/1.0',
+      'bypass-tunnel-reminder': 'true',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(
+      `Orchestrator service failed: ${response.statusText} - ${errorBody}`
+    );
   }
+
+  const result = await response.json();
+
+  return new Response(JSON.stringify(result), {
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+} catch (error) {
+  console.error('Error in claude-mashup-orchestrator proxy:', error.message);
+  return new Response(
+    JSON.stringify({
+      error: 'Failed to create masterplan',
+      details: error.message,
+    }),
+    {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    }
+  );
+}
 });


### PR DESCRIPTION
## Summary
- warn at startup when ORCHESTRATOR_API_URL is missing and return clear JSON error
- document required ORCHESTRATOR_API_URL under Supabase environment variables

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: Cannot find package '@eslint/js'...)*
- `curl -i -X POST http://localhost:8000 -d '{}' -H 'Content-Type: application/json'`


------
https://chatgpt.com/codex/tasks/task_e_68a0427a1d7c8322852dfd67ddcf330f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified required environment variables, including ORCHESTRATOR_API_URL, and referenced .env.example for the full list.
- Bug Fixes
  - Returns a clear 500 JSON error when the orchestrator URL is not configured, instead of failing unpredictably.
  - Standardized JSON error responses and status codes across failure paths.
  - Ensured OPTIONS preflight requests respond correctly with CORS headers.
- Improvements
  - More robust request handling with consistent responses when forwarding to the orchestrator succeeds or fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->