### PR TITLE
feat: clarify orchestrator env var handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ SEPARATION_API_URL=https://tylers-remixer-separation.loca.lt
 ```
 
 The `ORCHESTRATOR_API_URL` is required by the `claude-mashup-orchestrator` Supabase function.
-If it's missing, the function logs a warning at startup and returns a clear JSON error explaining that the variable is not set.
+If it's missing, the function logs a warning at startup and returns a JSON response:
+
+```json
+{
+  "error": "Missing ORCHESTRATOR_API_URL",
+  "details": "Set the ORCHESTRATOR_API_URL environment variable to the base URL of the orchestrator service."
+}
+```
 
 You will also need to add your `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `ANTHROPIC_API_KEY`. Refer to the `.env.example` file for the full list.

--- a/supabase/functions/claude-mashup-orchestrator/index.ts
+++ b/supabase/functions/claude-mashup-orchestrator/index.ts
@@ -7,7 +7,7 @@ const corsHeaders = {
 const orchestratorApiUrl = Deno.env.get('ORCHESTRATOR_API_URL');
 if (!orchestratorApiUrl) {
   console.warn(
-    'Warning: ORCHESTRATOR_API_URL environment variable is not set. Requests will fail.'
+    'ORCHESTRATOR_API_URL is not configured. The claude-mashup-orchestrator function cannot forward requests.'
   );
 }
 
@@ -19,8 +19,9 @@ if (req.method === 'OPTIONS') {
 if (!orchestratorApiUrl) {
   return new Response(
     JSON.stringify({
-      error: 'Missing environment variable',
-      details: 'ORCHESTRATOR_API_URL environment variable is not set.',
+      error: 'Missing ORCHESTRATOR_API_URL',
+      details:
+        'Set the ORCHESTRATOR_API_URL environment variable to the base URL of the orchestrator service.',
     }),
     {
       status: 500,


### PR DESCRIPTION
## Summary
- warn at startup when `ORCHESTRATOR_API_URL` missing and return explicit JSON error
- document required `ORCHESTRATOR_API_URL` in Supabase environment variables

## Testing
- `npm run test:integration` *(fails: tsx not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `deno run -A supabase/functions/claude-mashup-orchestrator/index.ts`
- `curl -i http://localhost:8000`


------
https://chatgpt.com/codex/tasks/task_e_68a0461a791c832296be4d74ba919f1e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When the orchestrator URL is not configured, the function now returns a clearer 500 JSON error with explicit fields and a more descriptive console warning, improving diagnosability.

* **Documentation**
  * Updated README to include a concrete JSON example for the missing ORCHESTRATOR_API_URL error and clearer guidance on setting the environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->