### PR TITLE
feat: type Masterplan and improve null safety

### DIFF
--- a/src/hooks/useMashupOrchestrator.ts
+++ b/src/hooks/useMashupOrchestrator.ts
@@ -3,7 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import type { Masterplan } from '@/types/masterplan';
 
 interface UseMashupOrchestratorReturn {
-  masterplan: any;
+  masterplan: Masterplan | null;
   creativeVision: string;
   finalAudioUrl: string | null;
   createMasterplan: (
@@ -11,7 +11,7 @@ interface UseMashupOrchestratorReturn {
     song2Analysis: any,
     mashabilityScore: any,
     userPreferences?: any
-  ) => Promise<any>;
+  ) => Promise<Masterplan>;
   executeMasterplan: (songs: any[], jobId: string) => Promise<string | null>;
   isCreating: boolean;
   isExecuting: boolean;
@@ -21,7 +21,7 @@ interface UseMashupOrchestratorReturn {
 }
 
 export const useMashupOrchestrator = (): UseMashupOrchestratorReturn => {
-  const [masterplan, setMasterplan] = useState<any>(null);
+  const [masterplan, setMasterplan] = useState<Masterplan | null>(null);
 
   const [creativeVision, setCreativeVision] = useState<string>('');
   const [finalAudioUrl, setFinalAudioUrl] = useState<string | null>(null);
@@ -55,12 +55,14 @@ export const useMashupOrchestrator = (): UseMashupOrchestratorReturn => {
       });
 
       if (invokeError) throw invokeError;
-      if (data?.error) throw new Error(data.details || 'Masterplan creation failed in API.');
+      if (!data || 'error' in data) throw new Error(data?.details || 'Masterplan creation failed in API.');
 
-      setMasterplan(data);
-      setCreativeVision(data.creative_vision);
+      const masterplanData: Masterplan = data;
 
-      return data;
+      setMasterplan(masterplanData);
+      setCreativeVision(masterplanData.creative_vision ?? '');
+
+      return masterplanData;
 
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Masterplan creation failed';

--- a/src/types/masterplan.ts
+++ b/src/types/masterplan.ts
@@ -1,3 +1,23 @@
+export interface Layer {
+  songId: string;
+  stem: string;
+  volume_db: number;
+  effects: string[];
+}
+
+export interface TimelineEntry {
+  time_start_sec: number;
+  duration_sec: number;
+  description: string;
+  energy_level: number;
+  layers: Layer[];
+}
+
+export interface ProblemSolution {
+  problem: string;
+  solution: string;
+}
+
 export interface Masterplan {
   creative_vision: string;
   masterplan: {
@@ -8,21 +28,7 @@ export interface Masterplan {
       targetKey: string;
       timeSignature: [number, number];
     };
-    timeline: Array<{
-      time_start_sec: number;
-      duration_sec: number;
-      description: string;
-      energy_level: number;
-      layers: Array<{
-        songId: string;
-        stem: string;
-        volume_db: number;
-        effects: string[];
-      }>;
-    }>;
-    problems_and_solutions: Array<{
-      problem: string;
-      solution: string;
-    }>;
+    timeline: TimelineEntry[];
+    problems_and_solutions: ProblemSolution[];
   };
 }

--- a/supabase/functions/generate-mashup/index.ts
+++ b/supabase/functions/generate-mashup/index.ts
@@ -742,11 +742,11 @@ export async function renderMashup(masterplan: Masterplan, songs: Song[], jobId:
       });
       
       console.log(`Prepared ${songsWithAnalysis.length} songs with analysis data for rendering`);
-      
+
       const requestBody = {
         masterplan: {
-          timeline: masterplan.masterplan.timeline,
-          global_settings: masterplan.masterplan.global
+          timeline: masterplan.masterplan?.timeline || [],
+          global_settings: masterplan.masterplan?.global
         },
         songs: songsWithAnalysis,
         job_id: jobId
@@ -1018,7 +1018,7 @@ export async function processBackground(jobId: string, songs: Song[]) {
     try {
       masterplan = await createMasterplan(analyses, scores);
       JobStateManager.setMasterplan(jobId, masterplan);
-      console.log(`Phase 3 complete: Generated masterplan "${masterplan.masterplan.title}" for job ${jobId}`);
+      console.log(`Phase 3 complete: Generated masterplan "${masterplan.masterplan?.title}" for job ${jobId}`);
     } catch (masterplanError) {
       console.error(`Masterplan generation failed for job ${jobId}:`, masterplanError);
       throw new Error(`Failed to generate creative masterplan: ${masterplanError.message}`);

--- a/supabase/functions/get-mashup-status/index.ts
+++ b/supabase/functions/get-mashup-status/index.ts
@@ -192,10 +192,10 @@ Deno.serve(async (req) => {
       
       // Job completion with actual audio URLs and metadata
       ...(jobState.result_url && { result_url: jobState.result_url }),
-      ...(jobState.masterplan && { 
-        title: jobState.masterplan.masterplan.title,
+      ...(jobState.masterplan && {
+        title: jobState.masterplan.masterplan?.title,
         concept: jobState.masterplan.creative_vision,
-        timeline: jobState.masterplan.masterplan.timeline
+        timeline: jobState.masterplan.masterplan?.timeline
       }),
       
       // Detailed metadata about processing progress


### PR DESCRIPTION
## Summary
- define detailed `Masterplan` interfaces
- use `Masterplan` in mashup orchestrator hook instead of `any`
- guard masterplan usage with optional chaining in orchestrator and API functions

## Testing
- `npm run typecheck` *(fails: Missing script "typecheck")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a046212d488322a2410af0dca73fbb