### PR TITLE
fix: ensure supabase edge calls include apikey

### DIFF
--- a/supabase_helpers.py
+++ b/supabase_helpers.py
@@ -1,0 +1,27 @@
+import os
+import json
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SUPABASE_URL = os.environ.get("SUPABASE_URL")
+SUPABASE_KEY = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+
+if not SUPABASE_URL or not SUPABASE_KEY:
+    raise RuntimeError("Supabase credentials are not configured")
+
+def invoke_supabase_function(function_name: str, payload: dict, timeout: int = 30):
+    """Call a Supabase Edge Function with proper headers and error handling."""
+    function_url = f"{SUPABASE_URL}/functions/v1/{function_name}"
+    headers = {
+        "Authorization": f"Bearer {SUPABASE_KEY}",
+        "apikey": SUPABASE_KEY,
+        "Content-Type": "application/json",
+    }
+    try:
+        response = requests.post(function_url, json=payload, headers=headers, timeout=timeout)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as exc:
+        raise RuntimeError(f"Failed to call edge function '{function_name}': {exc}") from exc


### PR DESCRIPTION
## Summary
- add shared helper to call Supabase Edge Functions with required `apikey` header
- use shared helper in audio processing service to resolve connection issues

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a0a44e5d948322aff12e5331697d5d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Centralized cloud service integration into shared helpers for consistent configuration and maintenance. No expected behavior change.
- Bug Fixes
  - Improved reliability of cloud function requests with standardized timeouts and stricter error handling.
  - Clearer error messages for missing credentials and network issues.
- Chores
  - Environment configuration now validated at startup to prevent misconfigured deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->